### PR TITLE
Fixed Brazilian Portuguese (pt-BR) language code to fix Issue #115

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -21,7 +21,7 @@ const // Versions
         'de', 	 // German
         'it', 	 // Italian
         'ko',	 // Korean
-        'pt-BR', // Brazilian Portuguese
+        'pt-br', // Brazilian Portuguese
         'ar',    // Arabic
         'tr'     // Turkish
     ]);


### PR DESCRIPTION
The value received in `let { word, language, version } = req.params` in **app.js** on **line 70** is converted to lowercase on **line 91** `language = language.toLowerCase();` however when checking if this value exists on **line 94** `if (!utils.isLanguageSupported(language)) { return handleError.call(res, new errors.NoDefinitionsFound()); }` is returned false due to the value being in capital letters in modules/utils.js ('pt-BR', // Brazilian Portuguese), thus an error is returned

[img1](https://i.imgur.com/7zbapJ7.png)
[img2](https://i.imgur.com/xDcfXtR.png)